### PR TITLE
Allow Rails 5 as well as 4.2+

### DIFF
--- a/schema_plus_default_expr.gemspec
+++ b/schema_plus_default_expr.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "activerecord", "~> 4.2"
+  gem.add_dependency "activerecord", ">= 4.2", "< 6"
   gem.add_dependency "schema_plus_core", "~> 1.0"
   gem.add_dependency "its-it", "~> 1.2"
 

--- a/schema_plus_default_expr.gemspec
+++ b/schema_plus_default_expr.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "activerecord", ">= 4.2", "< 6"
-  gem.add_dependency "schema_plus_core", "~> 1.0"
+  gem.add_dependency "activerecord", ">= 4.2", "< 6.0"
+  gem.add_dependency "schema_plus_core", ">= 1.0", "< 3.0"
   gem.add_dependency "its-it", "~> 1.2"
 
   gem.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
Simple pull request that allows schema_plus_default_expr to work with either the 1.x (4.2+) or 2.x (5.x) streams of schema_plus.
